### PR TITLE
CFund DB flush

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1663,20 +1663,16 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
                 if (pblocktree->GetProposalIndex(vProposals))
                 {
-                    if (vProposals.size() > 0)
+                    bool fMigrated = true;
+                    if (!pblocktree->ReadFlag("proposals_migrated", fMigrated) || !fMigrated)
                     {
                         LogPrintf("Importing %d proposals to the new CoinsDB...\n", vProposals.size());
-                        std::vector<std::pair<uint256, CFund::CProposal>> vToRemove;
                         for (auto& it: vProposals)
                         {
                             pcoinsTip->AddProposal(it);
-                            vToRemove.push_back(make_pair(it.hash, CProposal()));
                         }
-                        if (!pblocktree->UpdateProposalIndex(vToRemove))
-                        {
-                            strLoadError = _("Could not clean old Community Fund DB");
-                            break;
-                        }
+                        pcoinsTip->Flush();
+                        pblocktree->WriteFlag("proposals_migrated", true);
                     }
                 }
 
@@ -1684,20 +1680,17 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
                 if (pblocktree->GetPaymentRequestIndex(vPaymentRequests))
                 {
-                    if (vPaymentRequests.size() > 0)
+                    bool fMigrated = true;
+                    if (!pblocktree->ReadFlag("prequests_migrated", fMigrated) || !fMigrated)
                     {
                         LogPrintf("Importing %d payment requests to the new CoinsDB...\n", vPaymentRequests.size());
                         std::vector<std::pair<uint256, CFund::CPaymentRequest>> vToRemove;
                         for (auto& it: vPaymentRequests)
                         {
                             pcoinsTip->AddPaymentRequest(it);
-                            vToRemove.push_back(make_pair(it.hash, CPaymentRequest()));
                         }
-                        if (!pblocktree->UpdatePaymentRequestIndex(vToRemove))
-                        {
-                            strLoadError = _("Could not clean old Community Fund DB");
-                            break;
-                        }
+                        pcoinsTip->Flush();
+                        pblocktree->WriteFlag("proposals_migrated", true);
                     }
                 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1690,7 +1690,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                             pcoinsTip->AddPaymentRequest(it);
                         }
                         pcoinsTip->Flush();
-                        pblocktree->WriteFlag("proposals_migrated", true);
+                        pblocktree->WriteFlag("prequests_migrated", true);
                     }
                 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1672,11 +1672,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                         {
                             pcoinsTip->AddProposal(it);
                         }
-                        if (!pcoinsTip->Flush())
-                        {
-                            strLoadError = _("Failed to write to coin database");
-                            break;
-                        }
                     }
                 }
 
@@ -1692,11 +1687,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                         for (auto& it: vPaymentRequests)
                         {
                             pcoinsTip->AddPaymentRequest(it);
-                        }
-                        if (!pcoinsTip->Flush())
-                        {
-                            strLoadError = _("Failed to write to coin database");
-                            break;
                         }
                     }
                 }


### PR DESCRIPTION
This PR fixes a bug which caused the CFund DB to be empty when:
- the wallet uses a bootstrap from <4.7.0 and
- the process is killed before the db was automatically flushed to disk